### PR TITLE
Set default refresh.retain setting to 2, this matches what a classic …

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -60,6 +60,7 @@ defaults:
   system:
     experimental.user-daemons: true
     experimental.dbus-activation: true
+    refresh.retain: 2
 
 # Connect ubuntu-desktop-session
 connections:


### PR DESCRIPTION
…desktop has.

Desktops snaps are large and many so retaining three copies of each is likely to use excessive storage.