### PR TITLE
Add missing plugs for desktop-session

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -65,9 +65,13 @@ defaults:
 
 # Connect ubuntu-desktop-session
 connections:
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:account-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:avahi
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:desktop-launch
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:hardware-observe
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:home
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:hostname-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:locale-control
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:login-session-observe
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:login-session-control
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:mount-observe
@@ -79,6 +83,9 @@ connections:
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:snapd-control
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:system-observe
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:shell-config-files
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:time-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:timeserver-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:timezone-control
     slot: system:system-files
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:upower-observe
   - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:network-manager


### PR DESCRIPTION
These plugs aren't being connected by default to ubuntu-desktop-session, and are needed.

At least locale-control is required to allow to configure the locale and keyboard from gnome control center.