### PR TITLE
Bump ubuntu-seed to 7000M to allow more flexibility in seeding more snaps

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -25,7 +25,7 @@ volumes:
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-        size: 3500M
+        size: 7000M
         update:
           edition: 2
         content:


### PR DESCRIPTION
This will allow more flexibility for custom builds without the need for derivative gadget snaps.  We aren't targeting really small footprint devices here, and customers that are can create their own gadget snaps to suit that need.